### PR TITLE
Ip whitelisting

### DIFF
--- a/app/code/community/HE/TwoFactorAuth/Helper/Data.php
+++ b/app/code/community/HE/TwoFactorAuth/Helper/Data.php
@@ -18,6 +18,7 @@ class HE_TwoFactorAuth_Helper_Data extends Mage_Core_Helper_Abstract
         $this->_provider = Mage::getStoreConfig('he2faconfig/control/provider');
         $this->_logging = Mage::getStoreConfig('he2faconfig/control/logging');
         $this->_logAccess = Mage::getStoreConfig('he2faconfig/control/logaccess');
+        $this->_ipWhitelist = $this->getIPWhitelist();
     }
 
     public function isDisabled()
@@ -65,5 +66,17 @@ class HE_TwoFactorAuth_Helper_Data extends Mage_Core_Helper_Abstract
     {
         Mage::getModel('core/config')->saveConfig('he2faconfig/control/provider', 'disabled');
         Mage::app()->getStore()->resetConfig();
+    }
+
+    private function getIPWhitelist()
+    {
+        $return = [];
+        $ips = preg_split("/\r\n|\n|\r/", trim(Mage::getStoreConfig('he2faconfig/control/ipwhitelist')));
+        foreach ($ips as $ip) { 
+            if (filter_var($ip, FILTER_VALIDATE_IP)) { 
+                $return[] = trim($ip);
+            }           
+        }
+        return $return;
     }
 }

--- a/app/code/community/HE/TwoFactorAuth/Helper/Data.php
+++ b/app/code/community/HE/TwoFactorAuth/Helper/Data.php
@@ -79,4 +79,21 @@ class HE_TwoFactorAuth_Helper_Data extends Mage_Core_Helper_Abstract
         }
         return $return;
     }
+
+
+    public function inWhitelist($ip) 
+    {
+        if (count($this->_ipWhitelist) == 0) { return false; }
+
+        if (in_array( $ip, $this->_ipWhitelist )) { 
+            if ( $this->shouldLogAccess() ) {
+                Mage::log("TFA bypassed for IP $ip - whitelisted", 0, "two_factor_auth.log");
+            }
+            return true;
+        }
+        else { 
+            return false; 
+        }
+    }
+
 }

--- a/app/code/community/HE/TwoFactorAuth/Model/Observer.php
+++ b/app/code/community/HE/TwoFactorAuth/Model/Observer.php
@@ -28,6 +28,11 @@ class HE_TwoFactorAuth_Model_Observer
             return;
         }
 
+        // check ip-whitelist
+        if (Mage::helper('he_twofactorauth')->inWhitelist( Mage::helper('core/http')->getRemoteAddr() )) { 
+            Mage::getSingleton('admin/session')->set2faState(HE_TwoFactorAuth_Model_Validate::TFA_STATE_ACTIVE);
+        }
+
         if (Mage::getSingleton('admin/session')->get2faState() != HE_TwoFactorAuth_Model_Validate::TFA_STATE_ACTIVE) {
 
             if ($this->_shouldLog) {

--- a/app/code/community/HE/TwoFactorAuth/etc/system.xml
+++ b/app/code/community/HE/TwoFactorAuth/etc/system.xml
@@ -47,6 +47,19 @@
                             </comment>
                         </provider>
 
+                        <ipwhitelist>
+                            <label>Whitelisted IP Addresses</label>
+                            <frontend_type>textarea</frontend_type>
+                            <sort_order>15</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <comment>
+                                <![CDATA[
+                                    You may whitelist IP addresses here (one per line). Anyone logging in from a whitelisted IP will not be required to perform two-factor authentication.
+                                ]]>
+                            </comment>                 
+                        </ipwhitelist>
+
                         <logaccess>
                             <label>Enable access logging</label>
                             <frontend_type>select</frontend_type>


### PR DESCRIPTION
Adds an IP whitelisting feature - the user can specify IPs (one per line) in the back-end. Users logging in from these IP addresses do not need to use two factor.
