### PR TITLE
Disable check when resetting Google Authenticator user 

### DIFF
--- a/app/code/community/HE/TwoFactorAuth/Model/Observer.php
+++ b/app/code/community/HE/TwoFactorAuth/Model/Observer.php
@@ -211,9 +211,7 @@ class HE_TwoFactorAuth_Model_Observer
         // check that a user record has been saved
 
         // if google is turned and 2fa active...
-        if ((Mage::helper('he_twofactorauth')->getProvider() == 'google')
-            && (!Mage::helper('he_twofactorauth')->isDisabled())
-        ) {
+        if (Mage::helper('he_twofactorauth')->getProvider() == 'google') {
             $params = Mage::app()->getRequest()->getParams();
             if (isset($params['clear_google_secret'])) {
                 if ($params['clear_google_secret'] == 1) {


### PR DESCRIPTION
If the tfaoff.flag file was present, it was prevent the user from resetting their authenticator.

Fixes https://github.com/nexcess/magento-sentry-two-factor-authentication/issues/3
