### PR TITLE
Fix login issue for users with limited permissions

### DIFF
--- a/app/code/community/HE/TwoFactorAuth/controllers/Adminhtml/TwofactorController.php
+++ b/app/code/community/HE/TwoFactorAuth/controllers/Adminhtml/TwofactorController.php
@@ -27,6 +27,14 @@ class HE_TwoFactorAuth_Adminhtml_TwofactorController extends Mage_Adminhtml_Cont
         parent::_construct();
     }
 
+    /**
+     * Allow all admin users to access the 2fa forms
+     */
+    protected function _isAllowed()
+    {
+        return true;
+    }
+
     //need an action per provider so that we can load the correct 2fa form
 
     public function duoAction()


### PR DESCRIPTION
Fixes issue #6 

Magento expects admin controllers to override the `_isAllowed` method and check if the admin user is allowed access. If omitted, the default behavior of recent Magento versions can return `false` if the user has a limited set of permissions, notably the dashboard permission. Since we must allow all admin users access to the 2fa forms to complete login, simply returning `true` resolves this.